### PR TITLE
fix: adding rel=noopener noreferrer for security to links

### DIFF
--- a/components/Story/Story.styles.tsx
+++ b/components/Story/Story.styles.tsx
@@ -5,7 +5,7 @@ export const List = styled.li`
   margin-bottom: 2rem;
 `;
 
-export const Anchor = styled.a.attrs({ target: '_blank' })`
+export const Anchor = styled.a.attrs({ target: '_blank', rel: 'noopener noreferrer' })`
   text-decoration: none;
   color: #333;
   font-weight: 700;


### PR DESCRIPTION
## Description

Fixed a simple albeit important security miss where I made all links to articles open a new tab but left out the all-important [`rel: 'noopener noreferrer' `](https://developers.google.com/web/tools/lighthouse/audits/noopener)